### PR TITLE
set ros::Duration to 100 msec correctly in robot_control.cpp

### DIFF
--- a/mechatrobot/src/robot_control.cpp
+++ b/mechatrobot/src/robot_control.cpp
@@ -234,7 +234,7 @@ void controlLoop()
   // Create controller manager
   controller_manager::ControllerManager cm(&robot);
 
-  ros::Duration durp(100);  // 100 msec;
+  ros::Duration durp(0.1);  // 100 msec;
 
   ROS_INFO("started controlLoop");
   while (!g_quit)


### PR DESCRIPTION
3日目のチェックポイント4でステッピングモータが回らないバグを修正しました．
おそらくros::Ducationの1引数での指定の単位がsecでなところをmsecとして指定していたと思われる．